### PR TITLE
Suporte para códigos de conta iniciados em número

### DIFF
--- a/src/Modulos/MBAtividade.cpp
+++ b/src/Modulos/MBAtividade.cpp
@@ -22,9 +22,9 @@ bool MBAtividade::criar(Atividade novoAtividade)
     // verifica se uma Atividade com mesma tag ja existe
     if (MBAtividade::ler(novoAtividade)) return false;
 
-    string comando = "INSERT INTO ";
+    string comando = "INSERT INTO [";
     comando += novoAtividade.getValorCodigo();
-    comando += " (Tag, TagDestino, Nome, Data, Horario, Duracao, Preco, Avaliacao) VALUES ('";
+    comando += "] (Tag, TagDestino, Nome, Data, Horario, Duracao, Preco, Avaliacao) VALUES ('";
     comando += novoAtividade.getTag().getValor();            comando += "', '";
     comando += novoAtividade.getTagDestino().getValor();     comando += "', '";
     comando += novoAtividade.getValorNome();                 comando += "', '";
@@ -47,9 +47,9 @@ bool MBAtividade::criar(Atividade novoAtividade)
 
 void MBAtividade::criar(Codigo tabelaNova)
 {
-    string comando = "CREATE TABLE IF NOT EXISTS ";
+    string comando = "CREATE TABLE IF NOT EXISTS [";
     comando += tabelaNova.getValor();
-    comando += " (Tag, TagDestino, Nome, Data, Horario, Duracao, Preco, Avaliacao);";
+    comando += "] (Tag, TagDestino, Nome, Data, Horario, Duracao, Preco, Avaliacao);";
     char* errmsg;
     int rc = sqlite3_exec(banco, comando.c_str(), nullptr, 0, &errmsg);
     if (rc != SQLITE_OK)
@@ -65,9 +65,9 @@ bool MBAtividade::excluir(Atividade atividadeExcluir)
     // checa se a atividade existe
     if (!MBAtividade::ler(atividadeExcluir)) return false;
 
-    string comando = "DELETE FROM ";
+    string comando = "DELETE FROM [";
     comando += atividadeExcluir.getValorCodigo();
-    comando += " WHERE Tag='";
+    comando += "] WHERE Tag='";
     comando += atividadeExcluir.getTag().getValor();
     comando += "';";
 
@@ -83,9 +83,9 @@ bool MBAtividade::excluir(Atividade atividadeExcluir)
 
 void MBAtividade::excluir(Codigo tabelaExcluir)
 {
-    string comando = "DROP TABLE IF EXISTS ";
+    string comando = "DROP TABLE IF EXISTS [";
     comando += tabelaExcluir.getValor();
-    comando += " ;";
+    comando += "];";
     char* errmsg;
     int rc = sqlite3_exec(banco, comando.c_str(), nullptr, 0, &errmsg);
     if (rc != SQLITE_OK)
@@ -100,9 +100,9 @@ void MBAtividade::excluir(Codigo contaExcluir, Codigo destinoExcluir)
 {
     MBAtividade::criar(contaExcluir);
 
-    string comando = "DELETE FROM ";
+    string comando = "DELETE FROM [";
     comando += contaExcluir.getValor();
-    comando += " WHERE TagDestino='";
+    comando += "] WHERE TagDestino='";
     comando += destinoExcluir.getValor();
     comando += "';";
 
@@ -125,9 +125,9 @@ bool MBAtividade::ler(Atividade atividadeCheque)
     // garante que a conta tem uma tabela
     MBAtividade::criar(contaAssociada);
 
-    string comando = "SELECT Tag FROM ";
+    string comando = "SELECT Tag FROM [";
     comando += contaAssociada.getValor();
-    comando += " WHERE Tag='";
+    comando += "] WHERE Tag='";
     comando += tag.getValor();
     comando += "';";
 
@@ -161,9 +161,9 @@ std::vector<Atividade> MBAtividade::ler(Codigo contaCheque, Codigo destinoCheque
     // garante que a conta tem uma tabela
     MBAtividade::criar(contaCheque);
 
-    string comando = "SELECT Tag, TagDestino, Nome, Data, Horario, Duracao, Preco, Avaliacao FROM ";
+    string comando = "SELECT Tag, TagDestino, Nome, Data, Horario, Duracao, Preco, Avaliacao FROM [";
     comando += contaCheque.getValor();
-    comando += " WHERE TagDestino='";
+    comando += "] WHERE TagDestino='";
     comando += destinoCheque.getValor();
     comando += "';";
     sqlite3_stmt *stmt;
@@ -216,9 +216,9 @@ bool MBAtividade::atualizar(Atividade atividadeAtual, Nome novoNome)
     // checa se a atividade existe
     if (!MBAtividade::ler(atividadeAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += atividadeAtual.getValorCodigo();
-    comando += " SET Nome='";
+    comando += "] SET Nome='";
     comando += novoNome.getValor();
     comando += "' WHERE Tag='";
     comando += atividadeAtual.getTag().getValor();
@@ -240,9 +240,9 @@ bool MBAtividade::atualizar(Atividade atividadeAtual, Data novoData)
     // checa se a atividade existe
     if (!MBAtividade::ler(atividadeAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += atividadeAtual.getValorCodigo();
-    comando += " SET Data='";
+    comando += "] SET Data='";
     comando += novoData.getValor();
     comando += "' WHERE Tag='";
     comando += atividadeAtual.getTag().getValor();
@@ -264,9 +264,9 @@ bool MBAtividade::atualizar(Atividade atividadeAtual, Horario novoHorario)
     // checa se a atividade existe
     if (!MBAtividade::ler(atividadeAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += atividadeAtual.getValorCodigo();
-    comando += " SET Horario='";
+    comando += "] SET Horario='";
     comando += novoHorario.getValor();
     comando += "' WHERE Tag='";
     comando += atividadeAtual.getTag().getValor();
@@ -288,9 +288,9 @@ bool MBAtividade::atualizar(Atividade atividadeAtual, Duracao novoDuracao)
     // checa se a atividade existe
     if (!MBAtividade::ler(atividadeAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += atividadeAtual.getValorCodigo();
-    comando += " SET Duracao='";
+    comando += "] SET Duracao='";
     comando += to_string(novoDuracao.getValor());
     comando += "' WHERE Tag='";
     comando += atividadeAtual.getTag().getValor();
@@ -312,9 +312,9 @@ bool MBAtividade::atualizar(Atividade atividadeAtual, Dinheiro novoDinheiro)
     // checa se a atividade existe
     if (!MBAtividade::ler(atividadeAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += atividadeAtual.getValorCodigo();
-    comando += " SET Preco='";
+    comando += "] SET Preco='";
     comando += to_string(novoDinheiro.getValor());
     comando += "' WHERE Tag='";
     comando += atividadeAtual.getTag().getValor();
@@ -336,9 +336,9 @@ bool MBAtividade::atualizar(Atividade atividadeAtual, Avaliacao novoAvaliacao)
     // checa se a atividade existe
     if (!MBAtividade::ler(atividadeAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += atividadeAtual.getValorCodigo();
-    comando += " SET Avaliacao='";
+    comando += "] SET Avaliacao='";
     comando += to_string(novoAvaliacao.getValor());
     comando += "' WHERE Tag='";
     comando += atividadeAtual.getTag().getValor();

--- a/src/Modulos/MBDestino.cpp
+++ b/src/Modulos/MBDestino.cpp
@@ -28,9 +28,9 @@ bool MBDestino::criar(Destino novoDestino)
     // verifica se um destino com mesma tag ja existe
     if (MBDestino::ler(novoDestino)) return false;
 
-    string comando = "INSERT INTO ";
+    string comando = "INSERT INTO [";
     comando += novoDestino.getValorCodigo();
-    comando += " (Tag, TagViagem, Nome, Inicio, Fim, Avaliacao) VALUES ('";
+    comando += "] (Tag, TagViagem, Nome, Inicio, Fim, Avaliacao) VALUES ('";
     comando += novoDestino.getTag().getValor();            comando += "', '";
     comando += novoDestino.getTagViagem().getValor();      comando += "', '";
     comando += novoDestino.getValorNome();                 comando += "', '";
@@ -51,9 +51,9 @@ bool MBDestino::criar(Destino novoDestino)
 
 void MBDestino::criar(Codigo tabelaNova)
 {
-    string comando = "CREATE TABLE IF NOT EXISTS ";
+    string comando = "CREATE TABLE IF NOT EXISTS [";
     comando += tabelaNova.getValor();
-    comando += " (Tag, TagViagem, Nome, Inicio, Fim, Avaliacao);";
+    comando += "] (Tag, TagViagem, Nome, Inicio, Fim, Avaliacao);";
     char* errmsg;
     int rc = sqlite3_exec(banco, comando.c_str(), nullptr, 0, &errmsg);
     if (rc != SQLITE_OK)
@@ -74,9 +74,9 @@ bool MBDestino::excluir(Destino destinoExcluir)
     // exclui hospedagem associadas
     cntrIBHospedagem->excluir(Codigo(destinoExcluir.getValorCodigo()), destinoExcluir.getTag());
 
-    string comando = "DELETE FROM ";
+    string comando = "DELETE FROM [";
     comando += destinoExcluir.getValorCodigo();
-    comando += " WHERE Tag='";
+    comando += "] WHERE Tag='";
     comando += destinoExcluir.getTag().getValor();
     comando += "';";
 
@@ -97,9 +97,9 @@ void MBDestino::excluir(Codigo tabelaExcluir)
     // exclui hospedagens da conta
     cntrIBHospedagem->excluir(tabelaExcluir);
 
-    string comando = "DROP TABLE IF EXISTS ";
+    string comando = "DROP TABLE IF EXISTS [";
     comando += tabelaExcluir.getValor();
-    comando += " ;";
+    comando += "];";
     char* errmsg;
     int rc = sqlite3_exec(banco, comando.c_str(), nullptr, 0, &errmsg);
     if (rc != SQLITE_OK)
@@ -116,9 +116,9 @@ void MBDestino::excluir(Codigo contaExcluir, Codigo viagemExcluir)
 
     MBDestino::criar(contaExcluir);
 
-    string comando = "SELECT Tag FROM ";
+    string comando = "SELECT Tag FROM [";
     comando += contaExcluir.getValor();
-    comando += " WHERE TagViagem='";
+    comando += "] WHERE TagViagem='";
     comando += viagemExcluir.getValor();
     comando += "';";
 
@@ -153,9 +153,9 @@ void MBDestino::excluir(Codigo contaExcluir, Codigo viagemExcluir)
         cntrIBHospedagem->excluir(contaExcluir, Codigo(*itr));
     }
 
-    comando = "DELETE FROM ";
+    comando = "DELETE FROM [";
     comando += contaExcluir.getValor();
-    comando += " WHERE TagViagem='";
+    comando += "] WHERE TagViagem='";
     comando += viagemExcluir.getValor();
     comando += "';";
 
@@ -178,9 +178,9 @@ bool MBDestino::ler(Destino destinoCheque)
     // garante que a conta tem uma tabela
     MBDestino::criar(contaAssociada);
 
-    string comando = "SELECT Tag FROM ";
+    string comando = "SELECT Tag FROM [";
     comando += contaAssociada.getValor();
-    comando += " WHERE Tag='";
+    comando += "] WHERE Tag='";
     comando += tag.getValor();
     comando += "';";
 
@@ -214,9 +214,9 @@ std::vector<Destino> MBDestino::ler(Codigo contaCheque, Codigo viagemCheque)
     // garante que a conta tem uma tabela
     MBDestino::criar(contaCheque);
 
-    string comando = "SELECT Tag, Nome, Inicio, Fim, Avaliacao FROM ";
+    string comando = "SELECT Tag, Nome, Inicio, Fim, Avaliacao FROM [";
     comando += contaCheque.getValor();
-    comando += " WHERE TagViagem='";
+    comando += "] WHERE TagViagem='";
     comando += viagemCheque.getValor();
     comando += "';";
     sqlite3_stmt *stmt;
@@ -266,9 +266,9 @@ bool MBDestino::atualizar(Destino destinoAtual, Nome novoNome)
     // checa se o destino existe
     if (!MBDestino::ler(destinoAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += destinoAtual.getValorCodigo();
-    comando += " SET Nome='";
+    comando += "] SET Nome='";
     comando += novoNome.getValor();
     comando += "' WHERE Tag='";
     comando += destinoAtual.getTag().getValor();
@@ -290,8 +290,9 @@ bool MBDestino::atualizar(Destino destinoAtual, Data novaData, bool fim)
     // checa se o destino existe
     if (!MBDestino::ler(destinoAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += destinoAtual.getValorCodigo();
+    comando += "]";
     if (fim)
     {
         comando += " SET Inicio='";
@@ -321,9 +322,9 @@ bool MBDestino::atualizar(Destino destinoAtual, Avaliacao novaAvaliacao)
     // checa se o destino existe
     if (!MBDestino::ler(destinoAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += destinoAtual.getValorCodigo();
-    comando += " SET Avaliacao='";
+    comando += "] SET Avaliacao='";
     comando += to_string(novaAvaliacao.getValor());
     comando += "' WHERE Tag='";
     comando += destinoAtual.getTag().getValor();

--- a/src/Modulos/MBHospedagem.cpp
+++ b/src/Modulos/MBHospedagem.cpp
@@ -22,9 +22,9 @@ bool MBHospedagem::criar(Hospedagem novoHospedagem)
     // verifica se uma Hospedagem com mesma tag ja existe
     if (MBHospedagem::ler(novoHospedagem)) return false;
 
-    string comando = "INSERT INTO ";
+    string comando = "INSERT INTO [";
     comando += novoHospedagem.getValorCodigo();
-    comando += " (Tag, TagDestino, Nome, Avaliacao, Diaria) VALUES ('";
+    comando += "] (Tag, TagDestino, Nome, Avaliacao, Diaria) VALUES ('";
     comando += novoHospedagem.getTag().getValor();            comando += "', '";
     comando += novoHospedagem.getTagDestino().getValor();     comando += "', '";
     comando += novoHospedagem.getValorNome();                 comando += "', '";
@@ -44,9 +44,9 @@ bool MBHospedagem::criar(Hospedagem novoHospedagem)
 
 void MBHospedagem::criar(Codigo tabelaNova)
 {
-    string comando = "CREATE TABLE IF NOT EXISTS ";
+    string comando = "CREATE TABLE IF NOT EXISTS [";
     comando += tabelaNova.getValor();
-    comando += " (Tag, TagDestino, Nome, Avaliacao, Diaria);";
+    comando += "] (Tag, TagDestino, Nome, Avaliacao, Diaria);";
     char* errmsg;
     int rc = sqlite3_exec(banco, comando.c_str(), nullptr, 0, &errmsg);
     if (rc != SQLITE_OK)
@@ -62,9 +62,9 @@ bool MBHospedagem::excluir(Hospedagem hospedagemExcluir)
     // checa se a hospedagem existe
     if (!MBHospedagem::ler(hospedagemExcluir)) return false;
 
-    string comando = "DELETE FROM ";
+    string comando = "DELETE FROM [";
     comando += hospedagemExcluir.getValorCodigo();
-    comando += " WHERE Tag='";
+    comando += "] WHERE Tag='";
     comando += hospedagemExcluir.getTag().getValor();
     comando += "';";
 
@@ -80,9 +80,9 @@ bool MBHospedagem::excluir(Hospedagem hospedagemExcluir)
 
 void MBHospedagem::excluir(Codigo tabelaExcluir)
 {
-    string comando = "DROP TABLE IF EXISTS ";
+    string comando = "DROP TABLE IF EXISTS [";
     comando += tabelaExcluir.getValor();
-    comando += " ;";
+    comando += "];";
     char* errmsg;
     int rc = sqlite3_exec(banco, comando.c_str(), nullptr, 0, &errmsg);
     if (rc != SQLITE_OK)
@@ -97,9 +97,9 @@ void MBHospedagem::excluir(Codigo contaExcluir, Codigo destinoExcluir)
 {
     MBHospedagem::criar(contaExcluir);
 
-    string comando = "DELETE FROM ";
+    string comando = "DELETE FROM [";
     comando += contaExcluir.getValor();
-    comando += " WHERE TagDestino='";
+    comando += "] WHERE TagDestino='";
     comando += destinoExcluir.getValor();
     comando += "';";
 
@@ -122,9 +122,9 @@ bool MBHospedagem::ler(Hospedagem hospedagemCheque)
     // garante que a conta tem uma tabela
     MBHospedagem::criar(contaAssociada);
 
-    string comando = "SELECT Tag FROM ";
+    string comando = "SELECT Tag FROM [";
     comando += contaAssociada.getValor();
-    comando += " WHERE Tag='";
+    comando += "] WHERE Tag='";
     comando += tag.getValor();
     comando += "';";
 
@@ -158,9 +158,9 @@ std::vector<Hospedagem> MBHospedagem::ler(Codigo contaCheque, Codigo destinoCheq
     // garante que a conta tem uma tabela
     MBHospedagem::criar(contaCheque);
 
-    string comando = "SELECT Tag, TagDestino, Nome, Avaliacao, Diaria FROM ";
+    string comando = "SELECT Tag, TagDestino, Nome, Avaliacao, Diaria FROM [";
     comando += contaCheque.getValor();
-    comando += " WHERE TagDestino='";
+    comando += "] WHERE TagDestino='";
     comando += destinoCheque.getValor();
     comando += "';";
     sqlite3_stmt *stmt;
@@ -205,9 +205,9 @@ bool MBHospedagem::atualizar(Hospedagem hospedagemAtual, Nome novoNome)
     // checa se a hospedagem existe
     if (!MBHospedagem::ler(hospedagemAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += hospedagemAtual.getValorCodigo();
-    comando += " SET Nome='";
+    comando += "] SET Nome='";
     comando += novoNome.getValor();
     comando += "' WHERE Tag='";
     comando += hospedagemAtual.getTag().getValor();
@@ -229,9 +229,9 @@ bool MBHospedagem::atualizar(Hospedagem hospedagemAtual, Dinheiro novoDiaria)
     // checa se a hospedagem existe
     if (!MBHospedagem::ler(hospedagemAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += hospedagemAtual.getValorCodigo();
-    comando += " SET Diaria='";
+    comando += "] SET Diaria='";
     comando += to_string(novoDiaria.getValor());
     comando += "' WHERE Tag='";
     comando += hospedagemAtual.getTag().getValor();
@@ -253,9 +253,9 @@ bool MBHospedagem::atualizar(Hospedagem hospedagemAtual, Avaliacao novoAvaliacao
     // checa se a hospedagem existe
     if (!MBHospedagem::ler(hospedagemAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += hospedagemAtual.getValorCodigo();
-    comando += " SET Avaliacao='";
+    comando += "] SET Avaliacao='";
     comando += to_string(novoAvaliacao.getValor());
     comando += "' WHERE Tag='";
     comando += hospedagemAtual.getTag().getValor();

--- a/src/Modulos/MBViagem.cpp
+++ b/src/Modulos/MBViagem.cpp
@@ -30,9 +30,9 @@ bool MBViagem::criar(Viagem novaViagem)
     // garante que a conta tem uma tabela
     MBViagem::criar(Codigo(novaViagem.getValorCodigo()));
 
-    string comando = "INSERT INTO ";
+    string comando = "INSERT INTO [";
     comando += novaViagem.getValorCodigo();
-    comando += " (Tag, Nome, Avaliacao) VALUES ('";
+    comando += "] (Tag, Nome, Avaliacao) VALUES ('";
     comando += novaViagem.getTag().getValor();            comando += "', '";
     comando += novaViagem.getValorNome();                 comando += "', '";
     comando += to_string(novaViagem.getValorAvaliacao()); comando += "');";
@@ -51,9 +51,9 @@ bool MBViagem::criar(Viagem novaViagem)
 
 void MBViagem::criar(Codigo tabelaNova)
 {
-    string comando = "CREATE TABLE IF NOT EXISTS ";
+    string comando = "CREATE TABLE IF NOT EXISTS [";
     comando += tabelaNova.getValor();
-    comando += " (Tag, Nome, Avaliacao);";
+    comando += "] (Tag, Nome, Avaliacao);";
     char* errmsg;
     int rc = sqlite3_exec(banco, comando.c_str(), nullptr, 0, &errmsg);
     if (rc != SQLITE_OK)
@@ -72,9 +72,9 @@ bool MBViagem::excluir(Viagem viagemExcluir)
     // exclui destinos associados
     cntrIBDestino->excluir(Codigo(viagemExcluir.getValorCodigo()), viagemExcluir.getTag());
 
-    string comando = "DELETE FROM ";
+    string comando = "DELETE FROM [";
     comando += viagemExcluir.getValorCodigo();
-    comando += " WHERE Tag='";
+    comando += "] WHERE Tag='";
     comando += viagemExcluir.getTag().getValor();
     comando += "';";
     // cout << endl << comando;
@@ -94,9 +94,9 @@ void MBViagem::excluir(Codigo tabelaExcluir)
     // exclui destinos da conta
     cntrIBDestino->excluir(tabelaExcluir);
 
-    string comando = "DROP TABLE IF EXISTS ";
+    string comando = "DROP TABLE IF EXISTS [";
     comando += tabelaExcluir.getValor();
-    comando += ";";
+    comando += "];";
     char* errmsg;
     int rc = sqlite3_exec(banco, comando.c_str(), nullptr, 0, &errmsg);
     if (rc != SQLITE_OK)
@@ -115,9 +115,9 @@ bool MBViagem::ler(Viagem viagemCheque)
     // garante que a conta tem uma tabela
     MBViagem::criar(contaAssociada);
 
-    string comando = "SELECT Tag FROM ";
+    string comando = "SELECT Tag FROM [";
     comando += contaAssociada.getValor();
-    comando += " WHERE Tag='";
+    comando += "] WHERE Tag='";
     comando += tag.getValor();
     comando += "';";
 
@@ -151,15 +151,16 @@ std::vector<Viagem> MBViagem::ler(Codigo contaCheque)
     // garante que a conta tem uma tabela
     MBViagem::criar(contaCheque);
 
-    string comando = "SELECT Tag, Nome, Avaliacao FROM ";
+    string comando = "SELECT Tag, Nome, Avaliacao FROM [";
     comando += contaCheque.getValor();
-    comando += ";";
+    comando += "];";
     sqlite3_stmt *stmt;
     int rc = sqlite3_prepare_v2(banco, comando.c_str(), -1, &stmt, NULL);
     if (rc != SQLITE_OK)
     {
         string err = sqlite3_errmsg(banco);
-        throw runtime_error(err);
+        cerr << err << endl;
+        throw runtime_error(err); // aq
     }
     while ((rc = sqlite3_step(stmt)) == SQLITE_ROW)
     {
@@ -194,9 +195,9 @@ bool MBViagem::atualizar(Viagem viagemAtual, Avaliacao novoAvaliacao)
     // checa se a viagem existe
     if (!MBViagem::ler(viagemAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += viagemAtual.getValorCodigo();
-    comando += " SET Avaliacao='";
+    comando += "] SET Avaliacao='";
     comando += to_string(novoAvaliacao.getValor());
     comando += "' WHERE Tag='";
     comando += viagemAtual.getTag().getValor();
@@ -218,9 +219,9 @@ bool MBViagem::atualizar(Viagem viagemAtual, Nome novoNome)
     // checa se a viagem existe
     if (!MBViagem::ler(viagemAtual)) return false;
 
-    string comando = "UPDATE ";
+    string comando = "UPDATE [";
     comando += viagemAtual.getValorCodigo();
-    comando += " SET Nome='";
+    comando += "] SET Nome='";
     comando += novoNome.getValor();
     comando += "' WHERE Tag='";
     comando += viagemAtual.getTag().getValor();


### PR DESCRIPTION
Agora, os comandos SQLite3 referenciam os códigos das tabelas por "[código]", de forma que no banco de dados elas são registradas ainda como "código", sem os colchetes.

Assim, é possível executar um comando na tabela 123456 a referenciando por "[123456]" sem problemas no sistema (porém, ainda não há tratamento de erro para erros lançados pelos métodos de MBViagem, o que fazia crashar se uma conta de código numérico tentasse criar uma viagem).

PS.: só depois vi que funciona também com "keyword". [keyword] não é padrão do SQLite.
https://www.sqlite.org/lang_keywords.html